### PR TITLE
Fix Base.String depreciations to AbstractString for Julia v0.4

### DIFF
--- a/src/DBI.jl
+++ b/src/DBI.jl
@@ -37,7 +37,7 @@ module DBI
         columns::Vector{DatabaseColumn}
     end
 
-    function columninfo(db::DatabaseHandle, table::String, column::String)
+    function columninfo(db::DatabaseHandle, table::AbstractString, column::AbstractString)
         error("DBI API not fully implemented")
     end
 
@@ -105,11 +105,11 @@ module DBI
         error("DBI API not fully implemented")
     end
 
-    function prepare(db::DatabaseHandle, sql::String)
+    function prepare(db::DatabaseHandle, sql::AbstractString)
         error("DBI API not fully implemented")
     end
 
-    function Base.run(db::DatabaseHandle, sql::String)
+    function Base.run(db::DatabaseHandle, sql::AbstractString)
         stmt = prepare(db, sql)
         execute(stmt)
         finish(stmt)
@@ -127,11 +127,11 @@ module DBI
         return
     end
 
-    function sqlescape(sql::String)
+    function sqlescape(sql::AbstractString)
         error("Not yet implemented")
     end
 
-    function sql2jltype(t::String)
+    function sql2jltype(t::AbstractString)
         if t == "INT"
             return Int, 0
         elseif t == "REAL"
@@ -148,11 +148,11 @@ module DBI
         end
     end
 
-    function tableinfo(db::DatabaseHandle, table::String)
+    function tableinfo(db::DatabaseHandle, table::AbstractString)
         error("DBI API not fully implemented")
     end
 
-    function Base.select(db::DatabaseHandle, sql::String)
+    function Base.select(db::DatabaseHandle, sql::AbstractString)
         stmt = prepare(db, sql)
         execute(stmt)
         df = fetchdf(stmt)


### PR DESCRIPTION
This is a quick fix to bring the DBI package up to date with Julia v0.4.
Using `::String` was depreciated in favor of `::AbstractString`.

The fix prevents a vomit of depreciation warnings:
```julia
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.4.0 (2015-10-08 06:20 UTC)
 _/ |\__'_|_|_|\__'_|  |  Official http://julialang.org/ release
|__/                   |  x86_64-apple-darwin13.4.0

julia> using DBI
WARNING: Base.String is deprecated, use AbstractString instead.
  likely near /Users/pjames/.julia/v0.4/DBI/src/DBI.jl:40
WARNING: Base.String is deprecated, use AbstractString instead.
  likely near /Users/pjames/.julia/v0.4/DBI/src/DBI.jl:40
WARNING: Base.String is deprecated, use AbstractString instead.
  likely near /Users/pjames/.julia/v0.4/DBI/src/DBI.jl:108
WARNING: Base.String is deprecated, use AbstractString instead.
  likely near /Users/pjames/.julia/v0.4/DBI/src/DBI.jl:112
WARNING: Base.String is deprecated, use AbstractString instead.
  likely near /Users/pjames/.julia/v0.4/DBI/src/DBI.jl:130
WARNING: Base.String is deprecated, use AbstractString instead.
  likely near /Users/pjames/.julia/v0.4/DBI/src/DBI.jl:134
WARNING: Base.String is deprecated, use AbstractString instead.
  likely near /Users/pjames/.julia/v0.4/DBI/src/DBI.jl:151
WARNING: Base.String is deprecated, use AbstractString instead.
  likely near /Users/pjames/.julia/v0.4/DBI/src/DBI.jl:155
```
