### PR TITLE
Fix missing AbstractString on Julia 0.3

### DIFF
--- a/src/DBI.jl
+++ b/src/DBI.jl
@@ -18,6 +18,10 @@ module DBI
            sql2jltype,
            tableinfo
 
+    if !isdefined(:AbstractString)
+        const AbstractString = Base.String
+    end
+
     abstract DatabaseSystem
     abstract DatabaseHandle
     abstract StatementHandle


### PR DESCRIPTION
Fix missing AbstractString on Julia 0.3

```bash
julia -e 'Pkg.clone("git@github.com:JuliaDB/DBI.jl.git")'
julia -e 'using DBI'                                                                                                                             
ERROR: AbstractString not defined
....
while loading /home/moi/.julia/v0.3/DBI/src/DBI.jl, in expression starting on line 44
```