### PR TITLE
Add getconnection/transaction

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,9 +8,11 @@ across various database packages.
 ## Functions
 ```@docs
 DBInterface.connect
+DBInterface.getconnection
 DBInterface.prepare
 DBInterface.@prepare
 DBInterface.execute
+DBInterface.transaction
 DBInterface.executemany
 DBInterface.executemultiple
 DBInterface.close!


### PR DESCRIPTION
In `DBInterface.executemany`, it's much more efficient for databases to
wrap multiple `execute` invocations in transactions, so we add
`transaction` for individual database packages to overload and we need
`getconnection` in order to get the `Connection` for a `Statement`.