### PR TITLE
Declare whole interface as as public

### DIFF
--- a/src/DBInterface.jl
+++ b/src/DBInterface.jl
@@ -1,6 +1,9 @@
 module DBInterface
 
 export @sql_str;
+VERSION >= v"1.11.0-DEV.469" && eval(Meta.parse(
+"public connect, close!, getconnection, @prepare, prepare, execute, executemany, executemultiple, transaction, lastrowid, Error, Warning, ParameterError"
+))
 
 """
 Declare the string as written in SQL.

--- a/src/DBInterface.jl
+++ b/src/DBInterface.jl
@@ -2,7 +2,7 @@ module DBInterface
 
 export @sql_str;
 VERSION >= v"1.11.0-DEV.469" && eval(Meta.parse(
-"public connect, close!, getconnection, @prepare, prepare, execute, executemany, executemultiple, transaction, lastrowid, Error, Warning, ParameterError"
+"public Connection, Statement, Cursor, PositionalStatementParams, NamedStatementParams, StatementParams, connect, close!, getconnection, @prepare, prepare, execute, executemany, executemultiple, transaction, lastrowid, Error, Warning, ParameterError"
 ))
 
 """


### PR DESCRIPTION
This is already useful in practice with e.g. https://github.com/ericphanson/ExplicitImports.jl, which otherwise reports false positives for use of private implementation details.

Maintainer update:

- rebased onto the current `master`
- includes the documented interface types and parameter container aliases in the public API

Co-authored by Codex