### PR TITLE
Use GitHub token for documentation deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,3 @@ jobs:
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
## Summary

- Stop passing the stale `DOCUMENTER_KEY` to Documenter.
- Use the existing `GITHUB_TOKEN` with the job's `contents: write` permission.
- Restore documentation deployment from `master`.

## Root cause

Documenter prefers `DOCUMENTER_KEY` when it is present. The configured SSH key no longer authenticates, so deployment failed before the valid GitHub token could be used.

## Validation

- Workflow YAML parses.
- Documenter selects HTTPS authentication when only `GITHUB_TOKEN` is present.
- The full local documentation build passes.

Co-authored by Codex