### PR TITLE
Use GitHub token for TagBot releases

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -17,4 +17,3 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
## Summary

- use the repository `GITHUB_TOKEN` for TagBot tag pushes
- avoid selecting the stale SSH deploy key path

## Root cause

TagBot changes its Git remote to SSH whenever the `ssh` input is non-empty. The configured `DOCUMENTER_KEY` no longer authenticates to this repository, while the workflow already grants `contents: write` to `GITHUB_TOKEN`.

## Validation

- the workflow YAML parses
- `git diff --check` passes
- the final `master` documentation deploy proved the token permission path works

Co-authored by Codex